### PR TITLE
Improve reading in of config values

### DIFF
--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -24,7 +24,7 @@ var createCmd = &cobra.Command{
 			path = filepath.Base(dir)
 		}
 
-		if err := config.LoadConfig(cmd.Flags(), flag.IsSilent(cmd.Flags()), config.ConfigFilename, path); err != nil {
+		if err := config.LoadConfig(cmd.Flags(), flag.IsSilent(cmd.Flags()), config.ConfigFilename, path, true); err != nil {
 			cli.Fatalf("cannot create config file: %v", err)
 		}
 	},

--- a/config/azure_test.go
+++ b/config/azure_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestAzureNamifyReturnsHyphenatedStr(t *testing.T) {
-	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", ""); err != nil {
+	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", true); err != nil {
 		assert.Fail(t, "LoadConfig failed")
 	}
 	assert.Equal(t, namify("key", 20), "test-key-kekprt")
 }
 
 func TestAzureNamifyTruncatesNamesThatAreTooLong(t *testing.T) {
-	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", ""); err != nil {
+	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", true); err != nil {
 		assert.Fail(t, "LoadConfig failed")
 	}
 	namified := namify("this-is-a-really-long-key-that-should-be-truncated", 20)

--- a/config/config.go
+++ b/config/config.go
@@ -14,11 +14,11 @@ import (
 var stat = os.Stat
 var v = Persist(&ViperPersist{})
 
-func LoadConfig(flagSet *pflag.FlagSet, silent bool, projectConfigFile, projectName string) error {
+func LoadConfig(flagSet *pflag.FlagSet, silent bool, projectConfigFile, projectName string, requireConfig bool) error {
 	setConfigFile(projectConfigFile)
 	reader := bufio.NewReader(os.Stdin)
 
-	if !exists(projectConfigFile + configExtension) {
+	if !exists(projectConfigFile+configExtension) && requireConfig {
 		cli.Warningf("Project config file %s doesnt exist", projectConfigFile)
 		if silent {
 			return loadDefaultConfig(flagSet, true, projectConfigFile, projectName, reader)
@@ -67,8 +67,8 @@ func loadDefaultConfig(
 	return nil
 }
 
-func genericSetter(reader *bufio.Reader, prompt, def string, slient bool, setter func(string)) {
-	if slient {
+func genericSetter(reader *bufio.Reader, prompt, def string, silent bool, setter func(string)) {
+	if silent {
 		setter(def)
 	} else {
 		ans := cli.Input(reader, prompt, def, true)
@@ -79,7 +79,7 @@ func genericSetter(reader *bufio.Reader, prompt, def string, slient bool, setter
 func mustSetWithFlag(
 	reader *bufio.Reader,
 	prompt, def string,
-	slient bool,
+	silent bool,
 	flagSet *pflag.FlagSet,
 	flagName string,
 	setter func(string)) error {
@@ -88,7 +88,7 @@ func mustSetWithFlag(
 		return nil
 	}
 	val := def
-	if !slient {
+	if !silent {
 		val = cli.Input(reader, prompt, val, true)
 	}
 	if val == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,11 +19,41 @@ func TestLoadConfig_SetsViperDictionary(t *testing.T) {
 	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", true); err != nil {
 		assert.Fail(t, "LoadConfig failed")
 	}
-	assert.Equal(t, ProjectName(), "test")
-	assert.Equal(t, Remote(), "remote")
-	assert.Equal(t, TemplateVersion(), "v1")
-	assert.Equal(t, Deployment(), "standalone-graphql")
-	assert.Equal(t, v.GetString(uniqueStr), "kekprt")
+	assert.Equal(t, "test", ProjectName())
+	assert.Equal(t, "remote", Remote())
+	assert.Equal(t, "v1", TemplateVersion())
+	assert.Equal(t, "standalone-graphql", Deployment())
+	assert.Equal(t, "kekprt", v.GetString(uniqueStr))
+	assert.Equal(t, "master", Branch())
+}
+
+func TestLoadConfig_NoConfigRequiredConfigFileExists_LoadsConfigFile(t *testing.T) {
+	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", false); err != nil {
+		assert.Fail(t, "LoadConfig failed")
+	}
+	assert.Equal(t, "test", ProjectName())
+	assert.Equal(t, "remote", Remote())
+	assert.Equal(t, "kekprt", v.GetString(uniqueStr))
+	assert.Equal(t, "master", Branch())
+}
+
+func TestLoadConfig_NoConfigRequiredConfigFileDoesntExist_LoadsDefaultValues(t *testing.T) {
+	oldv := v
+	defer func() { v = oldv }()
+	v = Persist(NewMockPersist())
+
+	oldstat := stat
+	defer func() { stat = oldstat }()
+	stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+
+	if err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", false); err != nil {
+		assert.Fail(t, "LoadConfig failed")
+	}
+	assert.Equal(t, "", ProjectName())
+	assert.Equal(t, "", Remote())
+	assert.Equal(t, "master", Branch())
 }
 
 func TestLoadConfig_NoConfigNotSilentUserDoesntCreate_ReturnError(t *testing.T) {
@@ -72,10 +102,10 @@ func TestLoadConfig_NoConfigSilentWithRemote_CreatesDefaultConfig(t *testing.T) 
 
 	err := LoadConfig(flagSet, true, "./testdata/config_test", "", true)
 	require.NoError(t, err)
-	assert.Equal(t, Remote(), "github.com/mycompany")
-	assert.Equal(t, TemplateVersion(), "v1")
-	assert.Equal(t, Deployment(), "standalone-graphql")
-	assert.Equal(t, len(v.GetString(uniqueStr)), 6)
+	assert.Equal(t, "github.com/mycompany", Remote())
+	assert.Equal(t, "v1", TemplateVersion())
+	assert.Equal(t, "standalone-graphql", Deployment())
+	assert.Equal(t, 6, len(v.GetString(uniqueStr)))
 }
 
 func TestLoadConfig_NoConfigNotSilent_CreatesDefaultConfig(t *testing.T) {
@@ -92,10 +122,10 @@ func TestLoadConfig_NoConfigNotSilent_CreatesDefaultConfig(t *testing.T) {
 	mocks.WithMockStdio(t, "y\n"+stdinPass, func() {
 		err := LoadConfig(pflag.NewFlagSet("config", 1), false, "./testdata/config_test", "", true)
 		require.NoError(t, err)
-		assert.Equal(t, Remote(), "github.com/starkindustries")
-		assert.Equal(t, TemplateVersion(), "v1")
-		assert.Equal(t, Deployment(), "standalone-graphql")
-		assert.Equal(t, len(v.GetString(uniqueStr)), 6)
+		assert.Equal(t, "github.com/starkindustries", Remote())
+		assert.Equal(t, "v1", TemplateVersion())
+		assert.Equal(t, "standalone-graphql", Deployment())
+		assert.Equal(t, 6, len(v.GetString(uniqueStr)))
 	})
 }
 
@@ -116,16 +146,16 @@ func TestLoadConfig_NoConfigNotSilentWithFlag_DoesntPromptAndSetsFlagValue(t *te
 	mocks.WithMockStdio(t, "y\njarvis\n\n\ngrc.io/stark\n\n\n\n\n\n\n\n", func() {
 		err := LoadConfig(flagSet, false, "./testdata/config_test", "", true)
 		require.NoError(t, err)
-		assert.Equal(t, Remote(), "github.com/ironman")
-		assert.Equal(t, TemplateVersion(), "v1")
-		assert.Equal(t, Deployment(), "standalone-graphql")
-		assert.Equal(t, len(v.GetString(uniqueStr)), 6)
+		assert.Equal(t, "github.com/ironman", Remote())
+		assert.Equal(t, "v1", TemplateVersion())
+		assert.Equal(t, "standalone-graphql", Deployment())
+		assert.Equal(t, 6, len(v.GetString(uniqueStr)))
 	})
 }
 
 func TestGenericSetter_SetsDefaultWhenSilent(t *testing.T) {
 	genericSetter(bufio.NewReader(os.Stdin), "", "test", true, func(val string) {
-		assert.Equal(t, val, "test")
+		assert.Equal(t, "test", val)
 	})
 }
 
@@ -133,7 +163,7 @@ func TestGenericSetter_PromptsAndSetsUserInputWhenNotSilent(t *testing.T) {
 	mocks.WithMockStdio(t, "anothertest\n", func() {
 		reader := bufio.NewReader(os.Stdin)
 		genericSetter(reader, "", "test", false, func(val string) {
-			assert.Equal(t, val, "anothertest")
+			assert.Equal(t, "anothertest", val)
 		})
 	})
 }
@@ -142,7 +172,7 @@ func TestMustSetWithFlag_PrioritisesFlag(t *testing.T) {
 	flagSet := pflag.NewFlagSet("config", 1)
 	flagSet.String("exampleflag", "flagoverride", "")
 	err := mustSetWithFlag(bufio.NewReader(os.Stdin), "", "defaultval", false, flagSet, "exampleflag", func(val string) {
-		assert.Equal(t, val, "flagoverride")
+		assert.Equal(t, "flagoverride", val)
 	})
 	require.NoError(t, err)
 }
@@ -151,7 +181,7 @@ func TestMustSetWithFlag_UsesDefaultIfSilentAndNoFlag(t *testing.T) {
 	flagSet := pflag.NewFlagSet("config", 1)
 	flagSet.String("exampleflag", "", "")
 	err := mustSetWithFlag(bufio.NewReader(os.Stdin), "", "defaultval", true, flagSet, "exampleflag", func(val string) {
-		assert.Equal(t, val, "defaultval")
+		assert.Equal(t, "defaultval", val)
 	})
 	require.NoError(t, err)
 }
@@ -162,7 +192,7 @@ func TestMustSetWithFlag_PromptsWithDefaultIfNotSilentAndNoFlag(t *testing.T) {
 		flagSet := pflag.NewFlagSet("config", 1)
 		flagSet.String("exampleflag", "", "")
 		err := mustSetWithFlag(reader, "", "defaultval", false, flagSet, "exampleflag", func(val string) {
-			assert.Equal(t, val, "anothertest")
+			assert.Equal(t, "anothertest", val)
 		})
 		require.NoError(t, err)
 	})
@@ -177,8 +207,8 @@ func TestLoadDefaultConfig_SilentWithAllDefaults_SetsAllConfig(t *testing.T) {
 	flagSet.String(FlagRegistry, "gcr.io/mycompany", "")
 	err := loadDefaultConfig(flagSet, true, "configfile", "projectname", bufio.NewReader(os.Stdin))
 	require.NoError(t, err)
-	assert.Equal(t, Remote(), "github.com/mycompany")
-	assert.Equal(t, ProjectName(), "projectname")
+	assert.Equal(t, "github.com/mycompany", Remote())
+	assert.Equal(t, "projectname", ProjectName())
 	assert.Equal(t, defaultBranch, Branch())
 	assert.Equal(t, defaultTemplateVersion, TemplateVersion())
 }
@@ -202,8 +232,8 @@ func TestLoadDefaultConfig_NotSilent_SetsAllConfig(t *testing.T) {
 		flagSet := pflag.NewFlagSet("config", 1)
 		err := loadDefaultConfig(flagSet, false, "configfile", "projectname", reader)
 		require.NoError(t, err)
-		assert.Equal(t, Remote(), "github.com/starkindustries")
-		assert.Equal(t, ProjectName(), "jarvis")
+		assert.Equal(t, "github.com/starkindustries", Remote())
+		assert.Equal(t, "jarvis", ProjectName())
 	})
 
 }

--- a/config/constants.go
+++ b/config/constants.go
@@ -9,7 +9,7 @@ const (
 )
 
 const (
-	defaultTempalateVersion = "v1"
+	defaultTemplateVersion  = "v1"
 	defaultGatewayName      = "gateway"
 	defaultGraphqlName      = "graphql"
 	defaultDefaultNamespace = "default"
@@ -18,6 +18,7 @@ const (
 	defaultBranch           = "master"
 	defaultApiVersion       = "v1"
 	defaultDeployment       = DeployStandaloneGraphql
+	defaultRegistry         = "gcr.io"
 )
 
 const (
@@ -45,7 +46,7 @@ type DefaultConfig struct {
 }
 
 var defaultConfigsWithFlags = []DefaultConfig{
-	{"Default remote (e.g. github.com/<company-name>/<project>):", "", FlagRemote, SetRemote},
+	{"Default remote (e.g. github.com/<company-name>):", "", FlagRemote, SetRemote},
 	{"Default deployment:", defaultDeployment, FlagDeployment, SetDeployment},
 	{"Default service namespace:", defaultDefaultNamespace, FlagNamespace, SetDefaultNamespace},
 	{"Default registry (e.g. gcr.io):", "", FlagRegistry, SetRegistry},
@@ -54,7 +55,7 @@ var defaultConfigsWithFlags = []DefaultConfig{
 }
 
 var defaultConfigs = []DefaultConfig{
-	{"Template version:", defaultTempalateVersion, "", SetTemplateVersion},
+	{"Template version:", defaultTemplateVersion, "", SetTemplateVersion},
 	{"Default gateway service name:", defaultGatewayName, "", SetGatewayName},
 	{"Default graphql service name:", defaultGraphqlName, "", SetGraphqlName},
 	{"Default services directory:", defaultServicesDir, "", SetServicesDirectory},

--- a/config/infra.go
+++ b/config/infra.go
@@ -6,7 +6,7 @@ const (
 )
 
 func InfraDirectory() string {
-	return v.GetString(viperInfraDirectoryKey)
+	return v.GetStringOrDefault(viperInfraDirectoryKey, defaultInfraDir)
 }
 
 func SetInfraDirectory(s string) {

--- a/config/persist.go
+++ b/config/persist.go
@@ -5,6 +5,7 @@ import "github.com/spf13/viper"
 type Persist interface {
 	Set(key, value string)
 	GetString(key string) string
+	GetStringOrDefault(key string, defaultValue string) string
 	WriteConfig() error
 	WriteConfigAs(filename string) error
 	SetConfigName(name string)
@@ -20,6 +21,13 @@ func (v *ViperPersist) Set(key, value string) {
 
 func (v *ViperPersist) GetString(key string) string {
 	return viper.GetString(key)
+}
+
+func (v *ViperPersist) GetStringOrDefault(key string, defaultValue string) string {
+	if value := viper.GetString(key); value != "" {
+		return value
+	}
+	return defaultValue
 }
 
 func (v *ViperPersist) WriteConfig() error {

--- a/config/persist_test.go
+++ b/config/persist_test.go
@@ -18,6 +18,13 @@ func (m *MockPersist) GetString(key string) string {
 	return m.values[key]
 }
 
+func (m *MockPersist) GetStringOrDefault(key string, defaultValue string) string {
+	if value, ok := m.values[key]; ok {
+		return value
+	}
+	return defaultValue
+}
+
 func (m *MockPersist) WriteConfig() error {
 	return nil
 }

--- a/config/project.go
+++ b/config/project.go
@@ -21,7 +21,7 @@ func SetProjectName(s string) {
 }
 
 func TemplateVersion() string {
-	return v.GetString(viperProjectTemplateVersionKey)
+	return v.GetStringOrDefault(viperProjectTemplateVersionKey, defaultTemplateVersion)
 }
 
 func SetTemplateVersion(s string) {
@@ -37,7 +37,7 @@ func SetProvider(s string) {
 }
 
 func Deployment() string {
-	return v.GetString(viperProjectDeploymentKey)
+	return v.GetStringOrDefault(viperProjectDeploymentKey, defaultDeployment)
 }
 
 func SetDeployment(s string) {
@@ -53,7 +53,7 @@ func SetRemote(s string) {
 }
 
 func Registry() string {
-	return v.GetString(viperProjectRegistryKey)
+	return v.GetStringOrDefault(viperProjectRegistryKey, defaultRegistry)
 }
 
 func SetRegistry(s string) {
@@ -61,7 +61,7 @@ func SetRegistry(s string) {
 }
 
 func Branch() string {
-	return v.GetString(viperProjectBranchKey)
+	return v.GetStringOrDefault(viperProjectBranchKey, defaultBranch)
 }
 
 func SetBranch(s string) {
@@ -69,7 +69,7 @@ func SetBranch(s string) {
 }
 
 func ApiVersion() string {
-	return v.GetString(viperProjectApiVersionKey)
+	return v.GetStringOrDefault(viperProjectApiVersionKey, defaultApiVersion)
 }
 
 func SetApiVersion(s string) {

--- a/config/services.go
+++ b/config/services.go
@@ -9,7 +9,7 @@ const (
 )
 
 func GraphqlName() string {
-	return v.GetString(viperServicesGraphqlKey)
+	return v.GetStringOrDefault(viperServicesGraphqlKey, defaultGraphqlName)
 }
 
 func SetGraphqlName(s string) {
@@ -17,7 +17,7 @@ func SetGraphqlName(s string) {
 }
 
 func GatewayName() string {
-	return v.GetString(viperServicesGatewayKey)
+	return v.GetStringOrDefault(viperServicesGatewayKey, defaultGatewayName)
 }
 
 func SetGatewayName(s string) {
@@ -25,7 +25,7 @@ func SetGatewayName(s string) {
 }
 
 func DefaultNamespace() string {
-	return v.GetString(viperDefaultServicesNamespaceKey)
+	return v.GetStringOrDefault(viperDefaultServicesNamespaceKey, defaultDefaultNamespace)
 }
 
 func SetDefaultNamespace(s string) {
@@ -33,7 +33,7 @@ func SetDefaultNamespace(s string) {
 }
 
 func ServicesDirectory() string {
-	return v.GetString(viperServicesDirectoryKey)
+	return v.GetStringOrDefault(viperServicesDirectoryKey, defaultServicesDir)
 }
 
 func SetServicesDirectory(s string) {

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -49,7 +49,7 @@ func ConfigFlagset() *pflag.FlagSet {
 	conf.StringP(config.FlagApiVersion, "v", config.ApiVersion(), "api version to use")
 	conf.StringP(config.FlagTemplate, "t", "", "template to use")
 	conf.StringP(config.FlagDeployment, "d", config.Deployment(),
-		fmt.Sprintf("deployment pattern to use [%s, %s, %s]", config.DeployPlatform, config.DeployStandaloneGraphql))
+		fmt.Sprintf("deployment pattern to use [%s, %s]", config.DeployPlatform, config.DeployStandaloneGraphql))
 	conf.Bool(config.FlagSilent, false, "use default values for all flags and dont ask questions")
 	conf.Bool(config.FlagForce, false, "overwrite without asking questions")
 	return conf

--- a/placeholders/placeholders.go
+++ b/placeholders/placeholders.go
@@ -19,31 +19,22 @@ func getValueFromFlagSetOrConfig(flagSet *pflag.FlagSet, flagName string, config
 	return configFunc()
 }
 
-func NewProjectPlaceholders(flagSet *pflag.FlagSet,
-	projectRoot, projectName string) (*api_v1.PluginPlaceholders, error) {
-	return NewPlaceholders(flagSet, projectRoot, projectName, "", "")
-}
-
-func NewServicePlaceholders(flagSet *pflag.FlagSet,
-	projectRoot, moduleName, serviceName string) (*api_v1.PluginPlaceholders, error) {
-	return NewPlaceholders(flagSet, projectRoot, config.ProjectName(), moduleName, serviceName)
-}
-
-func NewDefaultServicePlaceholders(flagSet *pflag.FlagSet,
-	projectRoot, serviceName string) (*api_v1.PluginPlaceholders, error) {
-	return NewPlaceholders(flagSet, projectRoot, config.ProjectName(), "", serviceName)
-}
-
 func NewPlaceholders(flagSet *pflag.FlagSet,
 	rawProjectRoot,
 	rawProjectName,
 	rawServiceNamespace,
 	rawServiceName string) (*api_v1.PluginPlaceholders, error) {
+
 	// Project name is snake case for use as a variable
 	projectName := cases.Kebab(rawProjectName)
 	// replace the raw project name if there is a config project name
 	if config.ProjectName() != "" {
 		projectName = cases.Kebab(config.ProjectName())
+	}
+
+	projectRoot, err := filepath.Abs(rawProjectRoot)
+	if err != nil {
+		return nil, err
 	}
 
 	// Project directory is kebab case for use as a folder name
@@ -104,7 +95,7 @@ func NewPlaceholders(flagSet *pflag.FlagSet,
 
 	return &api_v1.PluginPlaceholders{
 		// project
-		ProjectRoot:      rawProjectRoot,
+		ProjectRoot:      projectRoot,
 		ProjectName:      projectName,
 		ProjectDirectory: projectDirectory,
 		ProjectFqn:       projectFqn,
@@ -127,7 +118,7 @@ func NewPlaceholders(flagSet *pflag.FlagSet,
 		ServiceVersionedNamespace: serviceNamespace + "." + version,
 		ServiceName:               serviceName,
 		ServiceFqn:                servicefqn,
-		ServiceDirectory:          filepath.Join(projectDirectory, servicesDir, serviceNamespace, rawServiceName),
+		ServiceDirectory:          filepath.Join(servicesDir, serviceNamespace, rawServiceName),
 		// infra
 		InfraDirectory: config.InfraDirectory(),
 		// messaging

--- a/plugins/command.go
+++ b/plugins/command.go
@@ -30,10 +30,9 @@ func GetCobraCommand(plugin plugins.Plugin, executor execute.Executor) (*cobra.C
 		Long:    usage.Long,
 		Example: usage.Example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if usage.RequiresConfig {
-				if err := initializeConfig(cmd); err != nil {
-					cli.Fatalf("cannot initialize config: %v", err)
-				}
+			err := initializeConfig(cmd, usage.RequiresConfig)
+			if err != nil && usage.RequiresConfig {
+				cli.Fatalf("cannot initialize config: %v", err)
 			}
 			p, err := placeholders.NewPlaceholders(cmd.Flags(), ".", "default", "", "")
 			if err != nil {
@@ -58,7 +57,7 @@ func GetCobraCommand(plugin plugins.Plugin, executor execute.Executor) (*cobra.C
 	return &cc, nil
 }
 
-func initializeConfig(cmd *cobra.Command) error {
+func initializeConfig(cmd *cobra.Command, requireConfig bool) error {
 	var path string
 	dir, err := os.Getwd()
 	if err != nil {
@@ -68,5 +67,5 @@ func initializeConfig(cmd *cobra.Command) error {
 	}
 
 	// load the project config file if it exists, otherwise prompt the user to create one
-	return config.LoadConfig(cmd.Flags(), flag.IsSilent(cmd.Flags()), config.ConfigFilename, path)
+	return config.LoadConfig(cmd.Flags(), flag.IsSilent(cmd.Flags()), config.ConfigFilename, path, requireConfig)
 }

--- a/plugins/plugins_dev.go
+++ b/plugins/plugins_dev.go
@@ -3,8 +3,15 @@
 package plugins
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	api_v1 "github.com/vision-cli/api/v1"
+	"github.com/vision-cli/common/execute"
+	"github.com/vision-cli/common/marshal"
 	"github.com/vision-cli/common/plugins"
-
+	"github.com/vision-cli/common/tmpl"
 	gatewayPlugin "github.com/vision-cli/vision-plugin-gateway-v1/plugin"
 	graphqlPlugin "github.com/vision-cli/vision-plugin-graphql-v1/plugin"
 	infraPlugin "github.com/vision-cli/vision-plugin-infra-v1/plugin"
@@ -45,5 +52,79 @@ func init() {
 			PluginPath:      "__vision-internal-plugin",
 			InternalCommand: servicePlugin.Handle,
 		},
+		plugins.Plugin{
+			Name:            "vision-plugin-debug-v1",
+			PluginPath:      "__vision-internal-plugin",
+			InternalCommand: printPluginRequest,
+		},
 	)
+}
+
+func printPluginRequest(input string, _ execute.Executor, _ tmpl.TmplWriter) string {
+	req, err := marshal.Unmarshal[api_v1.PluginRequest](input)
+	if err != nil {
+		return errorResponse(err)
+	}
+	result := ""
+	switch req.Command {
+	case api_v1.CommandUsage:
+		result, err = marshal.Marshal[api_v1.PluginUsageResponse](debugPluginUsage)
+		if err != nil {
+			return errorResponse(err)
+		}
+	case api_v1.CommandConfig:
+		result, err = marshal.Marshal[api_v1.PluginConfigResponse](debugPluginConfig)
+		if err != nil {
+			return errorResponse(err)
+		}
+	case api_v1.CommandRun:
+		formattedRequest, err := indent(input)
+		fmt.Println("Raw plugin request:", formattedRequest)
+		resp := api_v1.PluginResponse{
+			Result: "SUCCESS!",
+			Error:  "",
+		}
+		result, err = marshal.Marshal[api_v1.PluginResponse](resp)
+		if err != nil {
+			return errorResponse(err)
+		}
+	default:
+		return errorResponse(errors.New("unknown command"))
+	}
+	return result
+}
+
+var debugPluginUsage = api_v1.PluginUsageResponse{
+	Version:        "0.0.0",
+	Use:            "printRequest",
+	Short:          "print plugin request",
+	Long:           "print the request sent to a plugin",
+	Example:        "vision printRequest",
+	Subcommands:    []string{"debug"},
+	Flags:          []api_v1.PluginFlag{},
+	RequiresConfig: false,
+}
+
+var debugPluginConfig = api_v1.PluginConfigResponse{
+	Defaults: []api_v1.PluginConfigItem{},
+}
+
+func errorResponse(err error) string {
+	res, err := marshal.Marshal[api_v1.PluginResponse](api_v1.PluginResponse{
+		Result: "",
+		Error:  err.Error(),
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+	return res
+}
+
+func indent(rawJson string) (string, error) {
+	var buf bytes.Buffer
+	err := json.Indent(&buf, []byte(rawJson), "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(buf.Bytes()), nil
 }


### PR DESCRIPTION
* the ProjectRoot placeholder is now sent as an absolute path
* if a vision.json file is present in the current directory, it will be read in even if the plugin doesn't require a config
* where default values are available, these are now used instead of empty strings in the placeholders sent to the plugin even if no config is required

#7 